### PR TITLE
Fix two minor bugs and an annoyance

### DIFF
--- a/votemode.py
+++ b/votemode.py
@@ -64,11 +64,11 @@ def make_user_active(bot, trigger):
 @sopel.module.example('.activeusers')
 def show_active_users(bot, trigger):
     make_user_active(bot, trigger)
+    prune_active_users(bot)
     channel = trigger.sender
     if channel not in bot.memory['active_users']:
         bot.say("No active users")
         return
-    prune_active_users(bot)
     bot.say("There are %s eligible voters active in %s" % (str(len(bot.memory['active_users'][channel])), channel))
 
 def calculate_quota(bot, trigger, mode):
@@ -106,8 +106,8 @@ def votemode(bot, trigger, mode):
         clear_votes(bot)
     # Quota is 50% of active users plus one
     if trigger.group(2):
-        target = str(trigger.group(2)).strip().lower()
-        if not Identifier(target).is_nick():
+        target = Identifier(str(trigger.group(2)).strip().lower())
+        if not target.is_nick():
             return bot.reply("That is not a valid nick")
         if target not in bot.privileges[channel]:
             return bot.reply("I don't see that user.")

--- a/votemode.py
+++ b/votemode.py
@@ -73,7 +73,7 @@ def show_active_users(bot, trigger):
 
 def calculate_quota(bot, trigger, mode):
     channel = trigger.sender
-    quota = max(floor(len(bot.memory['active_users'][channel])*mode), 1)
+    quota = int(max(floor(len(bot.memory['active_users'][channel])*mode), 1))
     return quota
 
 def do_kick(bot, channel, target):


### PR DESCRIPTION
* Moved pruning earlier in `.activeusers`
If a user used `.activeusers` it would display potentially out-of-date activity numbers since pruning occurred after the `.activeusers` calculation.

* Use Identifier in the votemode target.
A nick like `beees|test` was previously unrecognized. This addresses issue #36 

* Made quota an integer so floating point numbers don't come up in output