### PR TITLE
Require user to be logged in in order to use heretic commands.

### DIFF
--- a/heretics.py
+++ b/heretics.py
@@ -3,8 +3,8 @@ import operator
 import sopel
 
 def setup(bot):
-    bot.cap_req('votemode', 'extended-join')
-    bot.cap_req('votemode', 'account-notify')
+    bot.cap_req('heretics', 'extended-join')
+    bot.cap_req('heretics', 'account-notify')
 
 @sopel.module.rule(r'\b([a-zA-Z_][a-zA-Z0-9\[\]\-\\`^{}\_]*) is a(?:n)? (heretic|haeretic|haeretick|heretick|heretike)\b')
 @sopel.module.rule(r'\b([a-zA-Z_][a-zA-Z0-9\[\]\-\\`^{}\_]*) are (heretic|haeretic|haeretick|heretick|heretike)s\b')

--- a/heretics.py
+++ b/heretics.py
@@ -9,12 +9,11 @@ def setup(bot):
 @sopel.module.rule(r'\b([a-zA-Z_][a-zA-Z0-9\[\]\-\\`^{}\_]*) is a(?:n)? (heretic|haeretic|haeretick|heretick|heretike)\b')
 @sopel.module.rule(r'\b([a-zA-Z_][a-zA-Z0-9\[\]\-\\`^{}\_]*) are (heretic|haeretic|haeretick|heretick|heretike)s\b')
 def denounce_heretic(bot, trigger):
-    bot.say("Attempting to denounce heretic")
     target = trigger.group(1)
     if trigger.account is None:
         return
     else:
-        nick = trigger.account
+        account = trigger.account
 
     channel = trigger.sender
 
@@ -28,11 +27,11 @@ def denounce_heretic(bot, trigger):
         defense_history = []
 
     # Now actually do the work.
-    if nick in defense_history:
-        defense_history.remove(nick)
+    if account in defense_history:
+        defense_history.remove(account)
 
-    if nick not in denounce_history:
-        denounce_history.append(nick)
+    if account not in denounce_history:
+        denounce_history.append(account)
 
     set_heretic_values(bot, target, channel, denounce_history, defense_history)
     bot.say('noted')
@@ -45,7 +44,7 @@ def deny_heresy(bot, trigger):
     if trigger.account is None:
         return
     else:
-        nick = trigger.account
+        account = trigger.account
 
     # Initialize the heretic
     denounce_key = 'denounce_%s' % str(target)
@@ -57,11 +56,11 @@ def deny_heresy(bot, trigger):
         defense_history = []
 
     # Now actually do the work.
-    if nick in denounce_history:
-        denounce_history.remove(nick)
+    if account in denounce_history:
+        denounce_history.remove(account)
 
-    if nick not in defense_history:
-        defense_history.append(nick)
+    if account not in defense_history:
+        defense_history.append(account)
 
     set_heretic_values(bot, target, channel, denounce_history, defense_history)
     bot.say('noted')
@@ -154,20 +153,20 @@ def denounced(bot, trigger):
 
     else:
         all_heretics = bot.db.get_channel_value(channel, 'heretics')
-        nick = trigger.account
-        if nick is None:
+        account = trigger.account
+        if account is None:
             bot.say("You must be authed to services to use this command.")
             return
-        denounced = [t for t in all_heretics if nick in bot.db.get_channel_value(channel, 'denounce_%s' % str(t))]
-        defended = [t for t in all_heretics if nick in bot.db.get_channel_value(channel, 'defense_%s' % str(t))]
+        denounced = [t for t in all_heretics if account in bot.db.get_channel_value(channel, 'denounce_%s' % str(t))]
+        defended = [t for t in all_heretics if account in bot.db.get_channel_value(channel, 'defense_%s' % str(t))]
         denounced=sorted(denounced, key=lambda s: s.lower())
         defended=sorted(defended, key=lambda s: s.lower())
         
         if len(denounced) == 0:
-            report = report + nick + ' has not denounced anything'
+            report = report + account + ' has not denounced anything'
         else:
             string = ", ".join(denounced)
-            report = report + nick + ' has denounced: ' + string
+            report = report + account + ' has denounced: ' + string
 
         if len(defended) == 0:
             report = report + ', and has not defended anything.'

--- a/heretics.py
+++ b/heretics.py
@@ -11,6 +11,7 @@ def setup(bot):
 def denounce_heretic(bot, trigger):
     target = trigger.group(1)
     if trigger.account is None:
+        bot.say('not noted')
         return
     else:
         account = trigger.account
@@ -42,6 +43,7 @@ def deny_heresy(bot, trigger):
     channel = trigger.sender
     target = trigger.group(1)
     if trigger.account is None:
+        bot.say('not noted')
         return
     else:
         account = trigger.account

--- a/votemode.py
+++ b/votemode.py
@@ -77,12 +77,12 @@ def make_user_quiet(bot,channel, nick):
 @sopel.module.priority('low')
 def make_user_active(bot, trigger):
     channel = trigger.sender
-    nick = trigger.account
-    if nick is None:
+    account = trigger.account
+    if account is None:
         return
     if channel not in bot.memory['active_users']:
         bot.memory['active_users'][channel] = dict()
-    bot.memory['active_users'][channel][nick] = datetime.now()
+    bot.memory['active_users'][channel][account] = datetime.now()
     clear_protection(bot, channel)
     clear_quiets(bot)
     prune_active_users(bot)
@@ -127,8 +127,8 @@ def do_moderated(bot, channel):
 def votemode(bot, trigger, mode):
     make_user_active(bot, trigger)
     channel = trigger.sender
-    nick = trigger.account
-    if nick is None:
+    account = trigger.account
+    if account is None:
         bot.say("You must be authed to use this command")
         return
     if bot.privileges[trigger.sender][bot.nick] < OP:
@@ -149,10 +149,10 @@ def votemode(bot, trigger, mode):
             return bot.reply("You cannot vote" + mode + " privileged users")
 
         if target in bot.memory['votes'][mode]:
-            if str(nick) not in bot.memory['votes'][mode][target]:
-                bot.memory['votes'][mode][target].append(str(nick))
+            if str(account) not in bot.memory['votes'][mode][target]:
+                bot.memory['votes'][mode][target].append(str(account))
         else:
-            bot.memory['votes'][mode][target] = [str(nick)]
+            bot.memory['votes'][mode][target] = [str(account)]
 
         bot.reply("Vote recorded. (%s more votes for action)" % str(max(0, quota - len(bot.memory['votes'][mode][target])+1)))
 
@@ -160,10 +160,10 @@ def votemode(bot, trigger, mode):
             bot.memory['vote_methods'][mode](bot, channel, target)
         bot.memory['last_vote'] = datetime.now()
     elif mode == "registered" or mode == "moderated":
-        if str(nick) not in bot.memory['votes'][mode]:
-            bot.memory['votes'][mode].append(str(nick))
+        if str(account) not in bot.memory['votes'][mode]:
+            bot.memory['votes'][mode].append(str(account))
         else:
-            bot.memory['votes'][mode] = [str(nick)]
+            bot.memory['votes'][mode] = [str(account)]
         bot.reply("Vote recorded. (%s more votes for action)" % str(max(0, quota - len(bot.memory['votes'][mode])+1)))
         if len(bot.memory['votes'][mode]) > quota:
             bot.memory['vote_methods'][mode](bot, channel)

--- a/votemode.py
+++ b/votemode.py
@@ -16,6 +16,8 @@ def clear_votes(bot):
                           }
 
 def setup(bot):
+    bot.cap_req('votemode', 'extended-join')
+    bot.cap_req('votemode', 'account-notify')
     bot.memory['active_users'] = dict()
     bot.memory['quiet_users'] = dict()
     bot.memory['last_vote'] = datetime.now()
@@ -75,7 +77,9 @@ def make_user_quiet(bot,channel, nick):
 @sopel.module.priority('low')
 def make_user_active(bot, trigger):
     channel = trigger.sender
-    nick = trigger.nick
+    nick = trigger.account
+    if nick is None:
+        return
     if channel not in bot.memory['active_users']:
         bot.memory['active_users'][channel] = dict()
     bot.memory['active_users'][channel][nick] = datetime.now()
@@ -123,7 +127,10 @@ def do_moderated(bot, channel):
 def votemode(bot, trigger, mode):
     make_user_active(bot, trigger)
     channel = trigger.sender
-    nick = trigger.nick
+    nick = trigger.account
+    if nick is None:
+        bot.say("You must be authed to use this command")
+        return
     if bot.privileges[trigger.sender][bot.nick] < OP:
         return bot.reply("I'm not a channel operator!")
     quota = calculate_quota(bot, trigger, bot.memory['mode_threshold'][mode])


### PR DESCRIPTION
This also allows underscores at the start of names (previously _joe was not hereticable).

A similar strategy can be used for `denom.py` and `votemode.py`, where we check account instead of nick.