### PR TITLE
Mitigate users stealing nicks.

### DIFF
--- a/denom.py
+++ b/denom.py
@@ -48,10 +48,7 @@ def set_denom(bot, trigger):
     bot.msg(sender, 'Sorry, you need to be authed to services to use this command.')
   elif len(denom) > length_limit:
     bot.reply('Denomination name too long. (Limit %s characters)' % str(length_limit))
-  elif person.lower() != account.lower():
-    bot.reply('You may only use setdenom while your nick matches your NickServ account name.')
   else:
-    claim_nick(bot, account, person)
     bot.db.set_nick_value(account, 'denom', denom)
     bot.msg(sender, 'Got it: %s is %s' % (person, denom))
 

--- a/denom.py
+++ b/denom.py
@@ -48,6 +48,8 @@ def set_denom(bot, trigger):
     bot.msg(sender, 'Sorry, you need to be authed to services to use this command.')
   elif len(denom) > length_limit:
     bot.reply('Denomination name too long. (Limit %s characters)' % str(length_limit))
+  elif person.lower() != account.lower():
+    bot.reply('You may only use setdenom while your nick matches your NickServ account name.')
   else:
     claim_nick(bot, account, person)
     bot.db.set_nick_value(account, 'denom', denom)
@@ -63,9 +65,9 @@ def get_denom(bot, trigger):
   try:
     target_account = str(bot.users[Identifier(person)].account)
   except:
-    target_account = None
-  if target_account == trigger.account:
-    claim_nick(bot, trigger.account, person)
+    bot.reply("I don't see %s"%person)
+    return
+  denom = bot.db.get_nick_value(target_account, 'denom')
 
   reply_via_msg = False
 
@@ -94,13 +96,13 @@ def get_denom(bot, trigger):
             reply_via_msg = True
 
   if reply_via_msg:
-    if bot.db.get_nick_value(person,'denom'):
-      bot.msg(person, '%s is %s' % (person, bot.db.get_nick_value(person,'denom')))
+    if denom is not None:
+      bot.msg(person, '%s is %s' % (person, denom))
     else:
       bot.msg(person, 'I don\'t know what %s is.' % person)
   else:
-    if bot.db.get_nick_value(person,'denom'):
-      bot.reply('%s is %s' % (person, bot.db.get_nick_value(person,'denom')))
+    if denom is not None:
+      bot.reply('%s is %s' % (person, denom))
     else:
       bot.reply('I don\'t know what %s is.' % person)
 


### PR DESCRIPTION
Only allow users to `.setdenom` when their nick matches their `NickServ` account.

Only allow users to `.denom` nicks that are currently in the channel.

If anyone comes up with a way to set user aliases without them being easily stolen, please let me know. This would allow us to let `.denom` work on offline nicks.